### PR TITLE
Implemented auto scaling of DonutChart

### DIFF
--- a/Sources/Microcharts.Shared/Extensions/CanvasExtensions.cs
+++ b/Sources/Microcharts.Shared/Extensions/CanvasExtensions.cs
@@ -7,10 +7,12 @@ namespace Microcharts
 
     public static class CanvasExtensions
     {
-        public static void DrawCaptionLabels(this SKCanvas canvas, string label, SKColor labelColor, string value, SKColor valueColor, float textSize, SKPoint point, SKTextAlign horizontalAlignment)
+        public static void DrawCaptionLabels(this SKCanvas canvas, string label, SKColor labelColor, string value, SKColor valueColor, float textSize, SKPoint point, SKTextAlign horizontalAlignment, out SKRect totalBounds)
         {
             var hasLabel = !string.IsNullOrEmpty(label);
             var hasValueLabel = !string.IsNullOrEmpty(value);
+
+            totalBounds = new SKRect();
 
             if (hasLabel || hasValueLabel)
             {
@@ -36,6 +38,9 @@ namespace Microcharts
                         var y = point.Y - ((bounds.Top + bounds.Bottom) / 2) - space;
 
                         canvas.DrawText(text, point.X, y, paint);
+
+                        var labelBounds = GetAbsolutePositionRect(point.X, y, bounds, horizontalAlignment);
+                        totalBounds = labelBounds.Standardized;
                     }
                 }
 
@@ -58,9 +63,49 @@ namespace Microcharts
                         var y = point.Y - ((bounds.Top + bounds.Bottom) / 2) + space;
 
                         canvas.DrawText(text, point.X, y, paint);
+
+                        var valueBounds = GetAbsolutePositionRect(point.X, y, bounds, horizontalAlignment);
+                        if (totalBounds.IsEmpty)
+                            totalBounds = valueBounds;
+                        else
+                            totalBounds.Union(valueBounds);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets the absolute bounds of a given rectangle, aligned at a given position.
+        /// </summary>
+        /// <param name="x">The absolute x position.</param>
+        /// <param name="y">The absolute y position.</param>
+        /// <param name="bounds">The bounds of the rectangle.</param>
+        /// <param name="horizontalAlignment">The alignment of the rectangle, relative to x/y.</param>
+        /// <returns></returns>
+        private static SKRect GetAbsolutePositionRect(float x, float y, SKRect bounds, SKTextAlign horizontalAlignment)
+        {
+            var captionBounds = new SKRect
+            {
+                Left = x + bounds.Left,
+                Top =  y + bounds.Top
+            };
+
+            switch (horizontalAlignment)
+            {
+                case SKTextAlign.Left:
+                    captionBounds.Right = captionBounds.Left + bounds.Width;
+                    break;
+                case SKTextAlign.Center:
+                    captionBounds.Right = captionBounds.Left + bounds.Width / 2;
+                    break;
+                case SKTextAlign.Right:
+                    captionBounds.Right = captionBounds.Left - bounds.Width;
+                    break;
+            }
+
+            captionBounds.Bottom = captionBounds.Top + bounds.Height;
+
+            return captionBounds;
         }
 
         /// <summary>

--- a/Sources/Microcharts.Shared/Layouts/DonutChart.cs
+++ b/Sources/Microcharts.Shared/Layouts/DonutChart.cs
@@ -23,6 +23,11 @@ namespace Microcharts
         /// <value>The hole radius.</value>
         public float HoleRadius { get; set; } = 0;
 
+        /// <summary>
+        /// Gets or sets a value whether the caption elements should all reside on the right side.
+        /// </summary>
+        public bool CaptionOnTheRight { get; set; }
+
         #endregion
 
         #region Methods
@@ -32,9 +37,21 @@ namespace Microcharts
             this.DrawCaption(canvas, width, height);
             using (new SKAutoCanvasRestore(canvas))
             {
-                canvas.Translate(width / 2, height / 2);
+                if (this.DrawDebugRectangles)
+                {
+                    using (var paint = new SKPaint
+                    {
+                        Color = SKColors.Red,
+                        IsStroke = true,
+                    })
+                    {
+                        canvas.DrawRect(this.DrawableChartArea, paint);
+                    }
+                }
+
+                canvas.Translate(this.DrawableChartArea.Left + this.DrawableChartArea.Width / 2 , height / 2);
                 var sumValue = this.Entries.Sum(x => Math.Abs(x.Value));
-                var radius = (Math.Min(width, height) - (2 * Margin)) / 2;
+                var radius = (Math.Min(this.DrawableChartArea.Width, this.DrawableChartArea.Height) - (2 * Margin)) / 2;
 
                 var start = 0.0f;
                 for (int i = 0; i < this.Entries.Count(); i++)
@@ -61,6 +78,12 @@ namespace Microcharts
 
         private void DrawCaption(SKCanvas canvas, int width, int height)
         {
+            if (this.CaptionOnTheRight)
+            {
+                this.DrawCaptionElements(canvas, width, height, this.Entries.ToList(), false);
+                return;
+            }
+
             var sumValue = this.Entries.Sum(x => Math.Abs(x.Value));
             var rightValues = new List<Entry>();
             var leftValues = new List<Entry>();

--- a/Sources/Microcharts.Shared/Layouts/RadarChart.cs
+++ b/Sources/Microcharts.Shared/Layouts/RadarChart.cs
@@ -144,7 +144,7 @@ namespace Microcharts
                         alignment = SKTextAlign.Right;
                     }
 
-                    canvas.DrawCaptionLabels(entry.Label, entry.TextColor, entry.ValueLabel, entry.Color, this.LabelTextSize, labelPoint, alignment);
+                    canvas.DrawCaptionLabels(entry.Label, entry.TextColor, entry.ValueLabel, entry.Color, this.LabelTextSize, labelPoint, alignment, out var labelBounds);
                 }
             }
         }


### PR DESCRIPTION
Hi Alois,

thanks for your awesome, simple and well written charting lib.

I used the DonutChart on a mobile device and ran into the same troubles as  #85.

So I extended your code to automatically calculate the drawable chart area - at least for the DonutChart:
![resize](https://user-images.githubusercontent.com/24974298/39376181-0907ba5a-4a51-11e8-8634-7c5674cd94b8.gif)

For future debugging I thought it might be useful to leave my debugging rectangles in the code - activatable by setting `Chart.DrawDebugRectangles`.

Also I found it useful to turn all the labels for the DonutChart to the right side to display a bigger chart on mobile devices in portrait form (`DonutChart.CaptionOnTheRight`)
![right](https://user-images.githubusercontent.com/24974298/39376222-3302a2c0-4a51-11e8-978e-63dc84de3b09.png)

This is my first pull request on github. If I missed something, please let me know.

Thomas